### PR TITLE
Implement bank sorting and bank title

### DIFF
--- a/tDF/mods/SUCC-bag.lua
+++ b/tDF/mods/SUCC-bag.lua
@@ -746,6 +746,14 @@ end)
 				GameTooltip:Hide()
 				ResetCursor()
 			end)
+			--- Add title to the bank frame, ensuring consistent font style with the bag frame
+    frame.bank.title = frame.bank:CreateFontString(nil, 'ARTWORK', 'GameFontNormal')
+    frame.bank.title:SetPoint('TOP', frame.bank, 11, -6)  -- Matching positioning with SUCC_bag
+    frame.bank.title.t = ''  -- Example custom text setup, adjust as needed
+    local playerName = UnitName("player")
+    frame.bank.title:SetText(frame.bank.title.t ~= '' and frame.bank.title.t ~= nil and frame.bank.title.t or (playerName .. "'s Bank"))
+	
+
 		end
 		StaticPopupDialogs['CONFIRM_BUY_SUCCBANK_SLOT'] = {
 			text = TEXT(CONFIRM_BUY_BANK_SLOT),
@@ -1208,21 +1216,60 @@ end)
 	end
 
 	--Start BagSort
-	-- Create the button
-	local button_tx = "Interface\\AddOns\\tDF\\Textures\\Sorting.tga"
-	local tBagSort = create_button("tBagSort", SUCC_bag, "TOPRIGHT", 18, 18,
+-- Create the bag sorting button
+local button_tx = "Interface\\AddOns\\tDF\\Textures\\Sorting.tga"
+local tBagSort = create_button("tBagSort", SUCC_bag, "TOPRIGHT", 18, 18,
     button_tx, button_tx, button_tx, nil, nil, nil, -30, -3,
-	function()
-		GameTooltip:SetOwner(this, "ANCHOR_RIGHT")
-		GameTooltip:SetText("Sort Bags", 1, 1, 1, 1, true)
-		GameTooltip:AddLine("This button sorts your bags to keep all of your items well organized.", nil, nil, nil, true)
-		GameTooltip:Show()
-	end,
-	function()
-		GameTooltip:Hide()
-	end,
-	function()
-		SortBags()
-	end)
+    function()
+        GameTooltip:SetOwner(this, "ANCHOR_RIGHT")
+        GameTooltip:SetText("Sort Bags", 1, 1, 1, 1, true)
+        GameTooltip:AddLine("This button sorts your bags to keep all of your items well organized.", nil, nil, nil, true)
+        GameTooltip:Show()
+    end,
+    function()
+        GameTooltip:Hide()
+    end,
+    function()
+        SortBags()  -- Function to sort bags
+    end)
+
+-- Function to create a sorting button attached to a specified parent frame
+local function CreateSortButton(name, parent, tooltipTitle, tooltipText, sortFunction)
+    local button_tx = "Interface\\AddOns\\tDF\\Textures\\Sorting.tga"
+    create_button(name, parent, "TOPRIGHT", 18, 18,
+        button_tx, button_tx, button_tx, nil, nil, nil, -30, -3,
+        function()
+            GameTooltip:SetOwner(this, "ANCHOR_RIGHT")
+            GameTooltip:SetText(tooltipTitle, 1, 1, 1, 1, true)
+            GameTooltip:AddLine(tooltipText, nil, nil, nil, true)
+            GameTooltip:Show()
+        end,
+        function()
+            GameTooltip:Hide()
+        end,
+        function()
+            sortFunction()  -- Function to sort items
+        end)
+end
+
+-- Event handler to prepare bank and create the bank sorting button when the bank frame is opened
+local function OnBankFrameOpened()
+    -- Initialize SUCC_bagBank if not already done
+    PrepareBank(SUCC_bag)
+    
+    -- Create the bank sorting button attached to SUCC_bagBank
+    CreateSortButton("tBankSort", SUCC_bagBank, "Sort Bank", "This button sorts your bank slots to keep all of your items well organized.", SortBankBags)
+end
+
+-- Register event to handle bank frame opening
+local eventFrame = CreateFrame("Frame")
+eventFrame:RegisterEvent("BANKFRAME_OPENED")
+eventFrame:SetScript("OnEvent", OnBankFrameOpened)
+
+
+
 
 end
+
+
+

--- a/tDF/mods/tBagSort.lua
+++ b/tDF/mods/tBagSort.lua
@@ -1,6 +1,6 @@
 local create_button = tDF.utils.create_button
 
--- Create the button
+-- Create the button for the main bags
 local button_tx = "Interface\\AddOns\\tDF\\img\\BagSort"
 local tBagSort = create_button("tBagSort", ContainerFrame1, "TOPRIGHT", 18, 18,
 button_tx, button_tx, button_tx, nil, nil, nil, -12, -30,
@@ -14,7 +14,27 @@ function()
     GameTooltip:Hide()
 end,
 function()
-    SortBags()
+    if BankFrame:IsVisible() then
+        SortBankBags()  -- Sorts the bank if the bank frame is open
+    else
+        SortBags()  -- Sorts the bags if the bank frame is not open
+    end
+end)
+
+-- Create the button specifically for the BankFrame
+local tBankSort = create_button("tBankSort", BankFrame, "TOPRIGHT", 18, 18,
+button_tx, button_tx, button_tx, nil, nil, nil, -45, -45,
+function()
+    GameTooltip:SetOwner(this, "ANCHOR_RIGHT")
+    GameTooltip:SetText("Sort Bank", 1, 1, 1, 1, true)
+    GameTooltip:AddLine("This button sorts your bank slots to keep all of your items well organized.", nil, nil, nil, true)
+    GameTooltip:Show()
+end,
+function()
+    GameTooltip:Hide()
+end,
+function()
+    SortBankBags()  -- Sorts the bank slots
 end)
 
 --SortBags


### PR DESCRIPTION
Add bank sorting icon and functionality to both default and AiO bags. 
Add bank title to match character's bags title.
![image](https://github.com/user-attachments/assets/fe186782-2e68-4fcb-ae4a-f6314e358aee)
![image](https://github.com/user-attachments/assets/0b445259-9bbc-4841-aed3-e9420c61c288)
