### PR TITLE
Update move-unitframes-extended.lua

### DIFF
--- a/tDF/mods/move-unitframes-extended.lua
+++ b/tDF/mods/move-unitframes-extended.lua
@@ -21,7 +21,8 @@ local nonmovables = {
   "MyCustomMinimap", -- minimap
   "tDFImprovedCastbar", -- player castbar
   "tDFbagMain", -- bags bar
-  "BuffButton0", -- buffs
+  "BuffButton0", -- buffrow1
+  "BuffButton8", -- buffrow2
   "BuffButton16", -- debuffs
   "TempEnchant1", -- weapon buffs
   "xpbar"


### PR DESCRIPTION
Makes the second row of buffs movable. The bar only appears if the player has more than 8 buffs at the same time.