### PR TITLE
Fix WorldMap Coordinates and UIOptionsFrame OnShow for Aero

### DIFF
--- a/mods/improved-interface-options.lua
+++ b/mods/improved-interface-options.lua
@@ -2,6 +2,7 @@
 -- Credit to Ko0z (https://github.com/Ko0z/)
 
 local T = tDFUI.T
+local HookScript = tDFUI.HookScript
 
 local module = tDFUI:register({
     title = T["Improved Interface Options"],
@@ -11,15 +12,7 @@ local module = tDFUI:register({
 })
 
 module.enable = function(self)
-    UIOptionsFrame:SetScript("OnShow", function()
-        -- default events
-        UIOptionsFrame_Load();
-        MultiActionBar_Update();
-        MultiActionBar_ShowAllGrids();
-        Disable_BagButtons();
-        UpdateMicroButtons();
-
-        -- customize
+    HookScript(UIOptionsFrame, "OnShow", function()
         UIOptionsBlackground:Hide()
         UIOptionsFrame:SetScale(.8)
     end)

--- a/mods/worldmap-coordinates.lua
+++ b/mods/worldmap-coordinates.lua
@@ -45,8 +45,10 @@ module.enable = function(self)
         local scale  = WorldMapButton:GetEffectiveScale()
         local x, y   = GetCursorPosition()
 
-        mx = (( x / scale ) - ( mx - width / 2)) / width * 100
-        my = (( my + height / 2 ) - ( y / scale )) / height * 100
+        if mx and my then
+          mx = (( x / scale ) - ( mx - width / 2)) / width * 100
+          my = (( my + height / 2 ) - ( y / scale )) / height * 100
+        end
 
         local px, py = GetPlayerMapPosition("player")
         if px > 0 and py > 0 then
@@ -55,7 +57,7 @@ module.enable = function(self)
           WorldMapButton.player.text:SetText(string.format("|cffffcc00" .. T["Player"] .. ": |r" .. T["N/A"]))
         end
 
-        if MouseIsOver(WorldMapButton) then
+        if mx and my and MouseIsOver(WorldMapButton) then
           WorldMapButton.coords.text:SetText(string.format("|cffffcc00" .. T["Cursor"] .. ": |r%.1f / %.1f", mx, my))
         else
           WorldMapButton.coords.text:SetText(string.format("|cffffcc00" .. T["Cursor"] .. ": |r" .. T["N/A"]))


### PR DESCRIPTION
This pull request addresses two issues specifically for [Aero](https://github.com/gashole/Aero)

1. WorldMap Coordinates

    - Fixes coordinate display errors when GetCenter() fails. See https://github.com/shagu/ShaguTweaks/commit/7e6c4ae

2. Improved Interface Options

    - Fixes the UIOptionsFrame OnShow script by using HookScript instead of overwriting it.

